### PR TITLE
fix(src/generator.ts): replace single quotes by space

### DIFF
--- a/__tests__/unit/index.ts
+++ b/__tests__/unit/index.ts
@@ -400,5 +400,24 @@ describe('Ground place unique id generation', () => {
         },
       ]);
     });
+
+    it("should return Pont-de-l'Arche expected gpuid", () => {
+      const gpuid = generator.gpuid({
+        name: "Pont-de-l'Arche",
+        latitude: 49.3169,
+        longitude: 1.16,
+        countryCode: 'fr',
+        type: 'group',
+      });
+
+      expect(gpuid).toEqual({
+        countryCode: 'fr',
+        id: 'g|FRpontarch@u0bbd3',
+        latitude: 49.3169,
+        longitude: 1.16,
+        name: "Pont-de-l'Arche",
+        type: 'group',
+      });
+    });
   });
 });

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -217,7 +217,7 @@ export class Generator {
    * @return {string}
    */
   private sanitize(str: string, countryCode:string): string {
-    const latinWord: string = this.replaceChar(str).toLowerCase().replace(/\(|\)|\.|'|\//gi, '').replace(/ +|-|'/gi, ' ');
+    const latinWord: string = this.replaceChar(str).toLowerCase().replace(/\(|\)|\.|"|\//gi, '').replace(/ +|-|'/gi, ' ');
     const cc: string = countryCode.toLowerCase() === 'be' ? 'fr' : countryCode.toLowerCase();
     const stopWords = sw[cc] || sw.en; // tslint:disable-line no-unsafe-any
 


### PR DESCRIPTION
This PR aims to:
Correct the GPUID generation by replacing single quotes by space in the places names, so it stays consistent with the AWS lamba GPUID generation.

Exemple:
```
{'countryCode': u'fr',
'latitude': 49.3169,
'longitude': 1.16,
'name': u"Pont-de-l'Arche",
'type': u'group'}
```
was generating `'g|FRpontlarc@u0bbd3'` (not consistent with the AWS lambda),
now generates `'g|FRpontarch@u0bbd3'` (consistent with the AWS lambda)